### PR TITLE
Support io.buildpacks.stacks.bionic stack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,7 +16,7 @@ api = "0.2"
 [buildpack]
 id = "heroku/java-function"
 name = "Java Function Buildpack"
-version = "0.3.0"
+version = "0.3.1"
 
 [[stacks]]
 id = "heroku-18"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -21,13 +21,16 @@ version = "0.3.0"
 [[stacks]]
 id = "heroku-18"
 
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"
+
 [[metadata.dependencies]]
 id      = "riff-invoker-java"
 name    = "riff Java Invoker"
 version = "0.1.4"
 uri     = "https://repo.spring.io/libs-milestone-local/io/projectriff/java-function-invoker/0.1.4/java-function-invoker-0.1.4-exec.jar"
 sha256  = "afdb65875c6e160571057083d063b5d506d3f4dff235abeebaa75f447bf02b66"
-stacks  = ["heroku-18"]
+stacks  = ["heroku-18", "io.buildpacks.stacks.bionic"]
 
   [[metadata.dependencies.licenses]]
   type = "Apache-2.0"


### PR DESCRIPTION
[This RFC](https://github.com/buildpacks/rfcs/pull/40) is working its way through and it seems useful to be able to use Heroku buildpacks on `cloudfoundry/cnb:bionic`. This also aligns with how riff is compatible with [multiple stacks](https://github.com/projectriff/node-function-buildpack/blob/master/buildpack.toml#L22).